### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ inst/doc
 optigrab.Rcheck/
 optigrab_*.gz
 
-
+# binary packages from building using install_local()
+R/*/

--- a/R/opt_get.R
+++ b/R/opt_get.R
@@ -144,7 +144,7 @@ opt_get <- function(
   ret <- opt_grab( flag=flag, n=n, opts=opts)
 
   
-  # Apply defaults, including trying to coerce to the defailts
+  # Apply defaults, including trying to coerce to the defaults
   # class
   if( ! missing(default) ) { 
     if( is.na(ret) ) 
@@ -157,7 +157,7 @@ opt_get <- function(
   if( is.na(ret) && missing(default) && required == TRUE )
     stop( 
           call. = FALSE 
-        , "\n\tOption(s): [", flag, "] is required, but was not supplied."
+        , "\n\tOption(s): [", paste(flag, collapse=", "), "] is required, but was not supplied."
     )
   
   

--- a/R/opt_help.R
+++ b/R/opt_help.R
@@ -62,7 +62,7 @@ opt_help <- function( name=c('help','?'), opts=commandArgs() ) {
     for( nm in names(opts) ) 
       cat( paste(' ', nm, ":", opts[[nm]], sep=" "), sep="\n" )
   
-  if( ! interactive() ) quit( save = FALSE )
+  if( ! interactive() ) quit( save = "no" )
   
   return(TRUE) 
   


### PR DESCRIPTION
I fixed two minor bugs. First, R would crash after displaying help with this error message:

```
    Error in quit(save = FALSE) :
      one of "yes", "no", "ask" or "default" expected.
    Calls: opt_help -> quit
    Execution halted
```

This is fixed in 1c5d53d0cd2f7d14672e031323bf8038f7c9e09e. Furthermore, missing required options with multiple flags got printed like this:

```
Option(s): [-p--project] is required, but was not supplied.
```

I fixed the output to make it more readable and standardized:

```
Option(s): [-p, --project] is required, but was not supplied.
```

Looking forward to your feedback! Thanks a lot for this awesome library, I've searched a lot for argument parsing in R, and across all the 6 libraries I checked out, this was the only one to provide a `required`-option which was very important to me.